### PR TITLE
Add leex extension to watchers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ export function activate(context: ExtensionContext) {
     documentSelector: [{ language: 'elixir', scheme: 'file' }, { language: 'elixir', scheme: 'untitled' }],
     synchronize: {
       configurationSection: 'elixirLS',
-      fileEvents: [workspace.createFileSystemWatcher('**/*.{ex,exs,erl,yrl,xrl,eex}')],
+      fileEvents: [workspace.createFileSystemWatcher('**/*.{ex,exs,erl,yrl,xrl,eex,leex}')],
     },
   };
 


### PR DESCRIPTION
This adds *.leex files to be watched. These are Phoenix LiveView embedded elixir files.

Mirrored from the VSCode LSP extension: https://github.com/elixir-lsp/vscode-elixir-ls/pull/83