### PR TITLE
Add trace config option

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,16 @@
           "default": "",
           "description": "Custom path for elixirLS, use this options if you don't want use bundled elixirLS"
         },
+        "elixir.trace.server": {
+          "type": "string",
+          "enum": [
+            "off",
+            "messages",
+            "verbose"
+          ],
+          "default": "off",
+          "description": "Traces the communication between VS Code and the Elixir language server."
+        },
         "elixirLS.dialyzerEnabled": {
           "type": "boolean",
           "default": true,


### PR DESCRIPTION
This adds the `"elixir.trace.server"` option

After enabling and using some of the LS features, this should give some details in the output channel. For example, I saw this:
```
[Trace - 1:38:53 AM] Sending notification 'initialized'.
Params: {}


[Trace - 1:38:53 AM] Sending notification 'workspace/didChangeConfiguration'.
Params: {
    "settings": {
        "elixirLS": {
            "dialyzerEnabled": false,
            "dialyzerWarnOpts": [],
            "dialyzerFormat": "dialyzer",
            "mixEnv": "test",
            "fetchDeps": true,
            "suggestSpecs": true,
            "trace": {
                "server": "off"
            }
        }
    }
}
```

Mirrors from vscode extension: https://github.com/elixir-lsp/vscode-elixir-ls/pull/10