### PR TITLE
Update the link to elixir-ls release in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Elixir language server extension based on [elixir-ls](https://github.com/elixir-
 ```
 Plug 'elixir-lsp/coc-elixir', {'do': 'yarn install && yarn prepack'}
 ```
-3. Get the latest elixir-ls release from [here](https://github.com/elixir-lsp/elixir-ls/releases/tag/v0.7.0) and unzip it into `~/.vim/plugged/coc-elixir/els-release` (`unzip elixir-ls.zip -d ~/.vim/plugged/coc-elixir/els-release`).
+3. Get the latest elixir-ls release from [here](https://github.com/elixir-lsp/elixir-ls/releases/latest) and unzip it into `~/.vim/plugged/coc-elixir/els-release` (`unzip elixir-ls.zip -d ~/.vim/plugged/coc-elixir/els-release`).
 
 ## Features
 - Go to definition support


### PR DESCRIPTION
The current link to elixir-ls releases is outdated.
It can simply point to the latest release instead.