### PR TITLE
Improve instructions for vim-plug installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,15 @@ Elixir language server extension based on [elixir-ls](https://github.com/elixir-
 ```
 Plug 'elixir-lsp/coc-elixir', {'do': 'yarn install && yarn prepack'}
 ```
-3. Get the latest elixir-ls release from [here](https://github.com/elixir-lsp/elixir-ls/releases/tag/v0.7.0) and unzip it into `~/.vim/plugged/coc-elixir/els-release` (`unzip elixir-ls.zip -d ~/.vim/plugged/coc-elixir/els-release`).
+3. Get the latest elixir-ls release from [here](https://github.com/elixir-lsp/elixir-ls/releases) and unzip it into `~/.vim/plugged/coc-elixir/els-release` (`unzip elixir-ls.zip -d ~/.vim/plugged/coc-elixir/els-release`).
+
+4. Create or update your coc-settings file and add this line:
+
+```
+{
+  "elixir.pathToElixirLS": "~/.vim/plugged/coc-elixir/els-release/language_server.sh"
+}
+```
 
 ## Features
 - Go to definition support


### PR DESCRIPTION
- Changed the link to download elixir-ls, which is pointing to a specific (very old) version. It's better to point to the whole list of available versions, where the latest one (supporting the latest versions of Elixir and Erlang) appears in the first place.

- Added a fourth last step to add the path where elixir-ls is stored to the cog-settings file. Without that coc-elixir cannot connect to the server, I think it's better to be explicit on this extra step.